### PR TITLE
add formatting for parameters and exceptions thrown

### DIFF
--- a/discord/src/main/java/me/piggypiglet/docdex/bot/embed/documentation/SimpleObjectSerializer.java
+++ b/discord/src/main/java/me/piggypiglet/docdex/bot/embed/documentation/SimpleObjectSerializer.java
@@ -86,7 +86,7 @@ public final class SimpleObjectSerializer {
     private static String formatEntrySet(@NotNull final Set<Map.Entry<String, String>> set) {
         return set.stream()
                 .filter(entry -> !entry.getValue().isBlank())
-                .map(entry -> entry.getKey() + " - " + entry.getValue())
+                .map(entry -> '`' + entry.getKey() + "` - " + entry.getValue())
                 .collect(Collectors.joining("\n"));
     }
 


### PR DESCRIPTION
In some cases, it is kinda hard to read the description of parameters or exceptions thrown because the text isn't separated very much
![image](https://user-images.githubusercontent.com/32105478/165087612-2af1e5a5-85c9-45dd-a67d-f152bbb98d1d.png)
